### PR TITLE
Non-null types

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 19
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/lib/power.dart
+++ b/lib/power.dart
@@ -7,19 +7,19 @@ class Power {
       const MethodChannel('com.amir_p/power');
 
   /// Uses method channel for getting low power mode.
-  static Future<bool?> get isLowPowerMode async {
+  static Future<bool> get isLowPowerMode async {
     return await _methodChannel.invokeMethod('getPowerMode');
   }
 
   /// Uses method channel for getting battery level.
   ///
   /// Returns -1 if batteryState is unknown in iOS
-  static Future<num?> get batteryLevel async {
+  static Future<num> get batteryLevel async {
     return await _methodChannel.invokeMethod('getBatteryLevel');
   }
 
   /// Uses method channel for getting charging status.
-  static Future<bool?> get isCharging async {
+  static Future<bool> get isCharging async {
     return await _methodChannel.invokeMethod('getChargingStatus');
   }
 }


### PR DESCRIPTION
1. As values are always going to come in results and if anything happens it's going to crash anyways. So no point in having null data types.
2. Lowered to SDK 19 on Android as it is always better to have minimum level support so everyone can use it.